### PR TITLE
Make into an ExtensionApp

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include pyproject.toml
 include README.md
 include RELEASE.md
 include MANIFEST.in
+include pytest.ini
 
 include package.json
 include copyAssets.js

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install from PyPI:
 ```
 This will automatically enable the extension in Jupyter Server.
 
-To test the installation, you can run Jupyter Server and visit the `/static/components/MathJax/MathJax.js` endpoint:
+To test the installation, you can run Jupyter Server and visit the `/static/jupyter_server_mathjax/MathJax.js` endpoint:
 ```
 > jupyter server
 ```

--- a/jupyter_server_mathjax/__init__.py
+++ b/jupyter_server_mathjax/__init__.py
@@ -1,22 +1,10 @@
-import os
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 
-from jupyter_server.base.handlers import FileFindHandler
-from jupyter_server.utils import url_path_join
+from .app import MathJaxExtension
 
-STATIC_ASSETS_PATH = os.path.join(os.path.dirname(__file__), 'static')
 
 def _jupyter_server_extension_points():
     return [
-        {
-            "module": "jupyter_server_mathjax",
-        },
+        {"module": "jupyter_server_mathjax", "app": MathJaxExtension},
     ]
-
-def _load_jupyter_server_extension(serverapp):
-    static_url_prefix = serverapp.web_app.settings['static_url_prefix']
-
-    serverapp.web_app.add_handlers('.*$', [
-        (url_path_join(static_url_prefix, r"components/MathJax/(.*)"), FileFindHandler, {
-            'path': STATIC_ASSETS_PATH,
-        })
-    ])

--- a/jupyter_server_mathjax/app.py
+++ b/jupyter_server_mathjax/app.py
@@ -1,0 +1,72 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from pathlib import Path
+from traitlets import default, observe, Unicode
+
+from tornado.web import RedirectHandler
+
+from jupyter_server.extension.application import ExtensionApp
+from jupyter_server.utils import url_path_join
+from jupyter_server.transutils import _
+
+
+STATIC_ASSETS_PATH = Path(__file__).parent / "static"
+
+
+class DeprecatedRedirectHandler(RedirectHandler):
+    def get(self, *args, **kwargs):
+        import warnings
+
+        warnings.warn(
+            "Redirecting old Notebook MathJax URL to new one. This will be removed in a future release.",
+            PendingDeprecationWarning,
+        )
+        super().get(*args, **kwargs)
+
+
+class MathJaxExtension(ExtensionApp):
+
+    name = "jupyter_server_mathjax"
+
+    # By listing the path to the assets here, jupyter_server
+    # automatically creates a static file handler at
+    # /static/jupyter_server_mathjax/...
+    static_paths = [str(STATIC_ASSETS_PATH)]
+
+    mathjax_config = Unicode(
+        "TeX-AMS-MML_HTMLorMML-full,Safe",
+        config=True,
+        help=_("""The MathJax.js configuration file that is to be used."""),
+    )
+
+    @observe("mathjax_config")
+    def _update_mathjax_config(self, change):
+        self.log.info(_("Using MathJax configuration file: %s"), change["new"])
+
+    def initialize_settings(self):
+        # Add settings specific to this extension to the
+        # tornado webapp settings.
+        self.settings.update({"mathjax_config": self.mathjax_config})
+
+    def initialize_handlers(self):
+        webapp = self.serverapp.web_app
+        base_url = self.serverapp.base_url
+        host_pattern = ".*$"
+
+        # Add a deprecated redirect for all MathJax paths from the classic
+        # notebook to the static endpoint created for this extension.
+        webapp.add_handlers(
+            host_pattern,
+            [
+                (
+                    url_path_join(base_url, "/static/components/MathJax/(.*)"),
+                    DeprecatedRedirectHandler,
+                    {
+                        "url": url_path_join(
+                            self.static_url_prefix, "/{0}"  # {0} = group 0 in url path
+                        )
+                    },
+                )
+            ],
+        )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+norecursedirs = .git node_modules htmlcov .ipynb_checkpoints
+testpaths = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,4 @@ known-excludes =
     package-lock.json
     *.egg-info/**/*
     .vscode/**/*
+    jupyter_server_mathjax/static/**/*

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 from pathlib import Path
 from setuptools import find_packages, setup
 from jupyter_packaging import (
@@ -20,8 +23,9 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 jstargets = [
-    here.joinpath(NAME, 'static', 'MathJax.js'),
-    here.joinpath(NAME, 'static', 'LICENSE'),  # We need to include the license if we are distributing MathJax
+    here.joinpath(NAME, "static", "MathJax.js"),
+    # if we are distributing MathJax, we need to include its license:
+    here.joinpath(NAME, "static", "LICENSE"),
 ]
 
 # Handle datafiles
@@ -30,9 +34,7 @@ cmdclass = create_cmdclass(
     data_files_spec=[
         ("etc/jupyter/jupyter_server_config.d", "jupyter_server_config.d", "*.json")
     ],
-    package_data_spec={
-        NAME: ['static/**/*']
-    }
+    package_data_spec={NAME: ["static/**/*"]},
 )
 
 cmdclass["js"] = combine_commands(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import io
 import logging
 import pytest
@@ -5,12 +8,7 @@ from traitlets import default
 
 pytest_plugins = ["jupyter_server.pytest_plugin"]
 
+
 @pytest.fixture
 def jp_server_config():
-    return {
-        "ServerApp": {
-            "jpserver_extensions": {
-                "jupyter_server_mathjax": True
-            }
-        }
-    }
+    return {"ServerApp": {"jpserver_extensions": {"jupyter_server_mathjax": True}}}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,15 +1,47 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 """Basic tests for the notebook handlers.
 """
 
+import pytest
+from tornado.httpclient import HTTPClientError
+from jupyter_server.utils import url_path_join as ujoin
+
 
 async def test_mathjax_mainjs_handler(jp_fetch):
-    r = await jp_fetch('static', 'components', 'MathJax', 'MathJax.js')
+    r = await jp_fetch("static", "jupyter_server_mathjax", "MathJax.js")
     assert r.code == 200
 
 
 async def test_mathjax_conf_handler(jp_fetch):
-    r = await jp_fetch('static', 'components', 'MathJax', 'config', 'TeX-AMS-MML_HTMLorMML-full.js')
+    r = await jp_fetch(
+        "static", "jupyter_server_mathjax", "config", "TeX-AMS-MML_HTMLorMML-full.js"
+    )
     assert r.code == 200
 
-    r = await jp_fetch('static', 'components', 'MathJax', 'config', 'Safe.js')
+    r = await jp_fetch("static", "jupyter_server_mathjax", "config", "Safe.js")
     assert r.code == 200
+
+
+@pytest.mark.parametrize(
+    "asset_file",
+    ["MathJax.js", "config/TeX-AMS-MML_HTMLorMML-full.js", "config/Safe.js"],
+)
+async def test_redirects_from_classic_notebook_endpoints(
+    jp_fetch, jp_base_url, asset_file
+):
+    old_prefix = ujoin("static", "components", "MathJax")
+    new_prefix = ujoin("static", "jupyter_server_mathjax")
+
+    # Verify that the redirect is in place
+    with pytest.raises(HTTPClientError) as error_info, pytest.deprecated_call(
+        match="Redirecting old Notebook MathJax URL .*"
+    ):
+        await jp_fetch(old_prefix, asset_file, follow_redirects=False)
+
+    err = error_info.value
+    assert err.code == 301
+    assert err.response.headers["Location"] == ujoin(
+        jp_base_url, new_prefix, asset_file
+    )


### PR DESCRIPTION
- Adds configurable trait "mathjax_config"
- Adds static files in namespace
- Redirects old notebook mathjax URLs to new ones, with a deprecation warning
- Adds some copyright comments in py files


The `mathjax_url` and `enable_mathjax` traits are not added, as these would probably make more sense to be front-end specific.