### PR TITLE
Correct git default branch name

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,7 +3,7 @@ name: Testing
 on:
   push:
     branches:
-    - master
+    - main
 
   pull_request:
     branches: '*'


### PR DESCRIPTION
This correct the name of the default branch in the GitHub action file from `master` to `main`.