### PR TITLE
Restore skip of windows/pypy CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,6 +20,8 @@ jobs:
         exclude:
         - os: macos
           python-version: pypy-3.8
+        - os: windows
+          python-version: pypy-3.8
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This removes testing on windows with pypy added in #12, which still appear to be flaky.